### PR TITLE
re-add bfe.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/bfe.json
+++ b/bfe.json
@@ -1,0 +1,66 @@
+[
+  {
+    "code": 0,
+    "type": "feed",
+    "sigil": "@",
+    "formats": [
+      { "code": 0, "format": "ssb/classic",     "data_length": 32, "suffix": ".ed25519"   },
+      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "suffix": ".ggfeed-v1" },
+      { "code": 2, "format": "bamboo",          "data_length": 32, "suffix": ".bamboo" },
+      { "code": 3, "format": "ssb/bendy-butt",  "data_length": 32, "suffix": ".bbfeed-v1" },
+      { "code": 4, "format": "ssb/fusion-identity", "data_length": 32, "suffix": ".fusion-v1" }
+    ]
+  },
+  {
+    "code": 1,
+    "type": "msg",
+    "sigil": "%",
+    "formats": [
+      { "code": 0, "format": "ssb/classic",     "data_length": 32, "suffix": ".sha256"   },
+      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "suffix": ".ggmsg-v1" },
+      { "code": 2, "format": "cloaked msg",     "data_length": 32, "suffix": ".cloaked" },
+      { "code": 3, "format": "bamboo",          "data_length": 64, "suffix": ".bamboo" },
+      { "code": 4, "format": "ssb/bendy-butt",  "data_length": 32, "suffix": ".bbmsg-v1" }
+    ]
+  },
+  {
+    "code": 2,
+    "type": "blob",
+    "sigil": "&",
+    "formats": [
+      { "code": 0, "format": "ssb/classic", "data_length": 32, "suffix": ".sha256" }
+    ]
+  },
+  {
+    "code": 3,
+    "type": "diffie-hellman",
+    "formats": [
+      { "code": 0, "format": "curve25519", "data_length": 32, "key_length": 32 }
+    ]
+  },
+  {
+    "code": 4,
+    "type": "signature",
+    "formats": [
+      { "code": 0, "format": "ed25519", "data_length": 64, "signature_length": 64, "suffix": ".sig.ed25519" }
+    ]
+  },
+  {
+    "code": 5,
+    "type": "encrypted",
+    "formats": [
+      { "code": 0, "format": "box1", "suffix": ".box" },
+      { "code": 1, "format": "box2", "suffix": ".box2" }
+    ]
+  },
+  {
+    "code": 6,
+    "type": "generic",
+    "formats": [
+      { "code": 0, "format": "UTF8 string" },
+      { "code": 1, "format": "boolean" },
+      { "code": 2, "format": "nil" },
+      { "code": 3, "format": "arbitrary bytes" }
+    ]
+  }
+]

--- a/bfe.test.js
+++ b/bfe.test.js
@@ -1,0 +1,41 @@
+const tape = require('tape')
+const bfeTypes = require('./bfe.json')
+
+tape('bfe', function (t) {
+  const sigiledTypes = bfeTypes.reduce((acc, type) => {
+    if (type.sigil) return [...acc, type]
+    return acc
+  }, [])
+  t.equal(
+    sigiledTypes.length,
+    new Set(sigiledTypes.map((type) => type.sigil)).size, // unique sigil
+    'each sigil is unique to a type'
+  )
+  t.equal(sigiledTypes.length, 3, 'there are only 3 sigils')
+
+  sigiledTypes.forEach(type => {
+    const typeSuffixes = type.formats.reduce((acc, format) => {
+      if (format.suffix && format.suffix.length) acc.add(format.suffix)
+      return acc
+    }, new Set())
+
+    t.equal(
+      typeSuffixes.size,
+      type.formats.length,
+      `each type/format with sigil ${type.sigil} has unique suffix` // unique to that type
+    )
+  })
+
+  const sigillessSuffixFormats = bfeTypes.reduce((acc, type) => {
+    if (type.sigil) return acc
+
+    return [...acc, ...type.formats.filter((format) => format.suffix)]
+  }, [])
+  t.equal(
+    sigillessSuffixFormats.length,
+    new Set(sigillessSuffixFormats.map((type) => type.suffix)).size,
+    'every suffix-only format is unique'
+  )
+
+  t.end()
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ssb-binary-field-encodings-spec",
+  "description": "Binary Field Encodings (BFE) spec for Secure Scuttlebutt (SSB)",
+  "version": "0.1.0",
+  "homepage": "https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec.git"
+  },
+  "main": "bfe.json",
+  "scripts": {
+    "test": "tape *.test.js | tap-spec"
+  },
+  "author": "Anders Rune Jensen <arj03@protonmail.ch>",
+  "contributors": [
+    "Andre Staltz <contact@staltz.com>",
+    "Mix Irving <mix@protozoa.nz>"
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "tap-spec": "^5.0.0",
+    "tape": "^5.3.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,22 +1,23 @@
 {
-  "name": "ssb-binary-field-encodings-spec",
+  "name": "ssb-bfe-spec",
   "description": "Binary Field Encodings (BFE) spec for Secure Scuttlebutt (SSB)",
   "version": "0.1.0",
-  "homepage": "https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec",
+  "homepage": "https://github.com/ssb-ngi-pointer/ssb-bfe-spec",
   "repository": {
     "type": "git",
-    "url": "git://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec.git"
+    "url": "git://github.com/ssb-ngi-pointer/ssb-bfe-spec.git"
   },
   "main": "bfe.json",
   "scripts": {
     "test": "tape *.test.js | tap-spec"
   },
-  "author": "Anders Rune Jensen <arj03@protonmail.ch>",
+  "author": "public-domain",
   "contributors": [
+    "Anders Rune Jensen <arj03@protonmail.ch>",
     "Andre Staltz <contact@staltz.com>",
     "Mix Irving <mix@protozoa.nz>"
   ],
-  "license": "MIT",
+  "license": "CC0-1.0",
   "devDependencies": {
     "tap-spec": "^5.0.0",
     "tape": "^5.3.1"


### PR DESCRIPTION
## context
in writing ssb-bfe we've been using a file bfe.json which is a representation of this spec. Conversation with mix/staltz/arj happened where we talked about how this repo would be a better place for this programmatically accessible definitions to live, to force alignment  of changes with it to be in step with the spec text

The intention is to merge this and then once we have settling some other PRs, to publish a tagged versions of this repo so we can be very clear about which version of this spec a person might be using.

We intent to then have ssb-bfe import this module and depend on it programmatically