### PR TITLE
name changes to types/format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ as **T-F-D**:
 
 ## Types
 
- | Type code   | Referencing        | In `bfe.json` |
- |:-----------:| ------------------ | ------------- |
- | 0           | Feed ID            | `feed`        |
- | 1           | Message ID         | `msg`         |
- | 2           | Blob ID            | `blob`        |
- | 3           | Encryption key     | `key`         |
- | 4           | Signature          | `signature`   |
- | 5           | Encrypted data     | `encrypted`   |
- | 6           | Generic data       | `generic`     |
- | 7           | Identity           | `identity`    |
+ | Type code   | Referencing        | In `bfe.json`    |
+ |:-----------:| ------------------ | ---------------- |
+ | 0           | Feed ID            | `feed`           |
+ | 1           | Message ID         | `msg`            |
+ | 2           | Blob ID            | `blob`           |
+ | 3           | Encryption key     | `encryption-key` |
+ | 4           | Signature          | `signature`      |
+ | 5           | Encrypted data     | `encrypted`      |
+ | 6           | Generic data       | `generic`        |
+ | 7           | Identity           | `identity`       |
 
 ### 0. Feed ID formats
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ as **T-F-D**:
  | 5           | encrypted          |
  | 6           | generic            |
 
-### 0. feed formats
+### 0. Feed ID formats
 
 A feed ID TFD represents the public portion of a cryptographic keypair used to
 identify a peer, and in turn identify feeds. Note however that there are some
@@ -58,7 +58,7 @@ type  │                    data
      format
 ```
 
-### 1. msg formats
+### 1. Msg ID formats
 
 A message ID TFD represents the hash that uniquely identifies a message
 published on a feed. Some message ID formats directly reference the hash
@@ -91,7 +91,7 @@ type  │                    data
      format
 ```
 
-### 2. blob formats
+### 2. Blob ID formats
 
 A blob ID TFD represents the hash that uniquely identifies the blob.
 
@@ -118,20 +118,20 @@ type  │                    data
      format
 ```
 
-### 3. key formats
+### 3. Encryption Key formats
 
 keys used for encryption
 
-| Type code | Format code | Data length | Format name | Specification |
-|:---------:|:-----------:|-------------|-------------|---------------|
-| 3         | 0           | 32 bytes    | envelope-dh |               |
+| Type code | Format code | Data length | Format name    | Specification      |
+|:---------:|:-----------:|-------------|----------------|--------------------|
+| 3         | 0           | 32 bytes    | box2-dm-dh     | [private group dm] |
 
 
-### 4. signature formats
+### 4. Signature formats
 
 | Type code | Format code | Data length | Format name     | specification |
 |:---------:|:-----------:|-------------|-----------------|---------------|
-| 4         | 0           | 64 bytes    | content-ed25519 |               |
+| 4         | 0           | 64 bytes    | msg-ed25519     |               |
 
 
 #### Example
@@ -153,7 +153,7 @@ type  │                    data
      format
 ```
 
-### 5. encrypted formats
+### 5. Encrypted data formats
 
 When content is encrypted (in other words, "boxed") in SSB, it is provided as
 uninterpretable bytes, plus a tag that identifies which algorithm was used for
@@ -162,9 +162,9 @@ encrypting it, such as `box` or `box2`.
 | Type code | Format code | Data length | Format name | Specification   |
 |:---------:|:-----------:|-------------|-------------|-----------------|
 | 5         | 0           | Arbitrary   | box1        | [private box]   |
-| 5         | 1           | Arbitrary   | box2        | [envelope spec] |
+| 5         | 1           | Arbitrary   | box2        | [private group] |
 
-### 6. generic formats
+### 6. Generic data formats
 
 BFE supports encoding data types with no semantics attached to them. They are
 merely categorized into formats that represent their data type.
@@ -180,7 +180,8 @@ merely categorized into formats that represent their data type.
 [classic]: https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format
 [gabby grove]: https://github.com/ssbc/ssb-spec-drafts/tree/master/drafts/draft-ssb-core-gabbygrove/00
 [bamboo]: https://github.com/AljoschaMeyer/bamboo
-[private group]: https://github.com/ssbc/private-group-spec
+[private group]: https://github.com/ssbc/private-group-spec/tree/master/encryption
+[private group dm]: https://github.com/ssbc/private-group-spec/tree/master/direct-messages
 [bendy butt]: https://github.com/ssb-ngi-pointer/bendy-butt-spec
 [private box]: https://ssbc.github.io/scuttlebutt-protocol-guide/#private-messages
 [envelope spec]: https://github.com/ssbc/envelope-spec

--- a/README.md
+++ b/README.md
@@ -15,29 +15,29 @@ as **T-F-D**:
 ## Types
 
  | Type code   | Referencing        |
- | ----------- | ------------------ |
- | 0           | Peer ID            |
- | 1           | Message ID         |
- | 2           | Blob ID            |
- | 3           | Diffie-Hellman key |
- | 4           | Signature          |
- | 5           | Encrypted data     |
- | 6           | Generic data       |
+ |:-----------:| ------------------ |
+ | 0           | feed               |
+ | 1           | msg                |
+ | 2           | blob               |
+ | 3           | key                |
+ | 4           | signature          |
+ | 5           | encrypted          |
+ | 6           | generic            |
 
-### Peer ID formats
+### 0. feed formats
 
-A peer ID TFD represents the public portion of a cryptographic keypair used to
+A feed ID TFD represents the public portion of a cryptographic keypair used to
 identify a peer, and in turn identify feeds. Note however that there are some
 identities that do not have a feed nor create messages, such as Fusion
 Identities.
 
 | Type code | Format code | Data length | Format name     | Specification    |
-|-----------|-------------|-------------|-----------------|------------------|
-| 0         | 0           | 32 bytes    | Classic         | [classic]        |
-| 0         | 1           | 32 bytes    | Gabby Grove     | [gabby grove]    |
-| 0         | 2           | 32 bytes    | Bamboo          | [bamboo]         |
-| 0         | 3           | 32 bytes    | Bendy Butt      | [bendy butt]     |
-| 0         | 4           | 32 bytes    | Fusion Identity | [fusionidentity] |
+|:---------:|:-----------:|-------------|-----------------|------------------|
+| 0         | 0           | 32 bytes    | classic         | [classic]        |
+| 0         | 1           | 32 bytes    | gabby-grove     | [gabby grove]    |
+| 0         | 2           | 32 bytes    | bamboo          | [bamboo]         |
+| 0         | 3           | 32 bytes    | bendy-butt      | [bendy butt]     |
+| 0         | 4           | 32 bytes    | fusion-identity | [fusionidentity] |
 
 #### Example
 
@@ -58,19 +58,19 @@ type  │                    data
      format
 ```
 
-### Message ID formats
+### 1. msg formats
 
 A message ID TFD represents the hash that uniquely identifies a message
 published on a feed. Some message ID formats directly reference the hash
 algorithm utilized, while others leave it implicit in the specification.
 
 | Type code | Format code | Data length | Format name   | Specification   |
-|---------- |-------------|-------------|---------------|-----------------|
-| 1         | 0           | 32 bytes    | Classic       | [classic]       |
-| 1         | 1           | 32 bytes    | Gabby Grove   | [gabby grove]   |
-| 1         | 2           | 32 bytes    | Cloaked group | [private group] |
-| 1         | 3           | 64 bytes    | Bamboo        | [bamboo]        |
-| 1         | 4           | 32 bytes    | Bendy Butt    | [bendy butt]    |
+|:---------:|:-----------:|-------------|---------------|-----------------|
+| 1         | 0           | 32 bytes    | classic       | [classic]       |
+| 1         | 1           | 32 bytes    | gabby-grove   | [gabby grove]   |
+| 1         | 2           | 32 bytes    | cloaked       | [private group] |
+| 1         | 3           | 64 bytes    | bamboo        | [bamboo]        |
+| 1         | 4           | 32 bytes    | bendy-butt    | [bendy butt]    |
 
 #### Example
 
@@ -91,13 +91,13 @@ type  │                    data
      format
 ```
 
-### Blob ID formats
+### 2. blob formats
 
 A blob ID TFD represents the hash that uniquely identifies the blob.
 
 | Type code | Format code | Data length | Format name | Specification |
-|-----------|-------------|-------------|-------------|---------------|
-| 2         | 0           | 32 bytes    | Classic     | [classic]     |
+|:---------:|:-----------:|-------------|-------------|---------------|
+| 2         | 0           | 32 bytes    | classic     | [classic]     |
 
 #### Example
 
@@ -118,17 +118,21 @@ type  │                    data
      format
 ```
 
-### Diffie-Hellman formats
+### 3. key formats
+
+keys used for encryption
 
 | Type code | Format code | Data length | Format name | Specification |
-|-----------|-------------|-------------|-------------|---------------|
-| 3         | 0           | 32 bytes    | curve25519  |               |
+|:---------:|:-----------:|-------------|-------------|---------------|
+| 3         | 0           | 32 bytes    | envelope-dh |               |
 
-### Signature formats
 
-| Type code | Format code | Data length | Format name | specification |
-|-----------|-------------|-------------|-------------|---------------|
-| 4         | 0           | 64 bytes    | ed25519     |               |
+### 4. signature formats
+
+| Type code | Format code | Data length | Format name     | specification |
+|:---------:|:-----------:|-------------|-----------------|---------------|
+| 4         | 0           | 64 bytes    | content-ed25519 |               |
+
 
 #### Example
 
@@ -149,28 +153,28 @@ type  │                    data
      format
 ```
 
-### Encrypted data formats
+### 5. encrypted formats
 
 When content is encrypted (in other words, "boxed") in SSB, it is provided as
 uninterpretable bytes, plus a tag that identifies which algorithm was used for
 encrypting it, such as `box` or `box2`.
 
 | Type code | Format code | Data length | Format name | Specification   |
-|-----------|-------------|-------------|-------------|-----------------|
-| 5         | 0           | Arbitrary   | box         | [private box]   |
+|:---------:|:-----------:|-------------|-------------|-----------------|
+| 5         | 0           | Arbitrary   | box1        | [private box]   |
 | 5         | 1           | Arbitrary   | box2        | [envelope spec] |
 
-### Generic data formats
+### 6. generic formats
 
 BFE supports encoding data types with no semantics attached to them. They are
 merely categorized into formats that represent their data type.
 
 | Type code | Format code | Data length | Format name | Specification                 |
-|-----------|-------------|-------------|-------------|-------------------------------|
-| 6         | 0           | Arbitrary   | UTF8 string | [UTF8]                        |
-| 6         | 1           | 1 byte      | Boolean     | Data byte is 0 for False, 1 for True |
-| 6         | 2           | 0 bytes     | Nil         | [null pointer]                |
-| 6         | 3           | Arbitrary   | Arbitrary bytes | N/A |
+|:---------:|:-----------:|-------------|-------------|-------------------------------|
+| 6         | 0           | Arbitrary   | string-UTF8 | [UTF8]                        |
+| 6         | 1           | 1 byte      | boolean     | Data byte is 0 for False, 1 for True |
+| 6         | 2           | 0 bytes     | nil         | [null pointer]                |
+| 6         | 3           | Arbitrary   | any-bytes   | N/A |
 
 [TFK]: https://github.com/ssbc/envelope-spec/blob/master/encoding/tfk.md
 [classic]: https://ssbc.github.io/scuttlebutt-protocol-guide/#message-format

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ merely categorized into formats that represent their data type.
 | 6         | 0           | Arbitrary   | string-UTF8 | [UTF8]                        |
 | 6         | 1           | 1 byte      | boolean     | Data byte is 0 for False, 1 for True |
 | 6         | 2           | 0 bytes     | nil         | [null pointer]                |
-| 6         | 3           | Arbitrary   | any-bytes   | N/A |
+| 6         | 3           | Arbitrary   | any-bytes   | Arbitrary sequence of bytes |
 
 
 ### 7. Identity formats

--- a/bfe.json
+++ b/bfe.json
@@ -35,14 +35,14 @@
     "code": 3,
     "type": "key",
     "formats": [
-      { "code": 0, "format": "envleope-dh", "data_length": 32, "key_length": 32 }
+      { "code": 0, "format": "box2-dm-dh", "data_length": 32, "key_length": 32 }
     ]
   },
   {
     "code": 4,
     "type": "signature",
     "formats": [
-      { "code": 0, "format": "content-ed25519", "data_length": 64, "signature_length": 64, "suffix": ".sig.ed25519" }
+      { "code": 0, "format": "msg-ed25519", "data_length": 64, "signature_length": 64, "suffix": ".sig.ed25519" }
     ]
   },
   {

--- a/bfe.json
+++ b/bfe.json
@@ -4,11 +4,11 @@
     "type": "feed",
     "sigil": "@",
     "formats": [
-      { "code": 0, "format": "ssb/classic",     "data_length": 32, "suffix": ".ed25519"   },
-      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "suffix": ".ggfeed-v1" },
-      { "code": 2, "format": "bamboo",          "data_length": 32, "suffix": ".bamboo" },
-      { "code": 3, "format": "ssb/bendy-butt",  "data_length": 32, "suffix": ".bbfeed-v1" },
-      { "code": 4, "format": "ssb/fusion-identity", "data_length": 32, "suffix": ".fusion-v1" }
+      { "code": 0, "format": "classic",     "data_length": 32, "suffix": ".ed25519"   },
+      { "code": 1, "format": "gabby-grove", "data_length": 32, "suffix": ".ggfeed-v1" },
+      { "code": 2, "format": "bamboo",      "data_length": 32, "suffix": ".bamboo" },
+      { "code": 3, "format": "bendy-butt",  "data_length": 32, "suffix": ".bbfeed-v1" },
+      { "code": 4, "format": "fusion-identity", "data_length": 32, "suffix": ".fusion-v1" }
     ]
   },
   {
@@ -16,11 +16,11 @@
     "type": "msg",
     "sigil": "%",
     "formats": [
-      { "code": 0, "format": "ssb/classic",     "data_length": 32, "suffix": ".sha256"   },
-      { "code": 1, "format": "ssb/gabby-grove", "data_length": 32, "suffix": ".ggmsg-v1" },
-      { "code": 2, "format": "cloaked msg",     "data_length": 32, "suffix": ".cloaked" },
-      { "code": 3, "format": "bamboo",          "data_length": 64, "suffix": ".bamboo" },
-      { "code": 4, "format": "ssb/bendy-butt",  "data_length": 32, "suffix": ".bbmsg-v1" }
+      { "code": 0, "format": "classic",     "data_length": 32, "suffix": ".sha256"   },
+      { "code": 1, "format": "gabby-grove", "data_length": 32, "suffix": ".ggmsg-v1" },
+      { "code": 2, "format": "cloaked",     "data_length": 32, "suffix": ".cloaked" },
+      { "code": 3, "format": "bamboo",      "data_length": 64, "suffix": ".bamboo" },
+      { "code": 4, "format": "bendy-butt",  "data_length": 32, "suffix": ".bbmsg-v1" }
     ]
   },
   {
@@ -28,21 +28,21 @@
     "type": "blob",
     "sigil": "&",
     "formats": [
-      { "code": 0, "format": "ssb/classic", "data_length": 32, "suffix": ".sha256" }
+      { "code": 0, "format": "classic", "data_length": 32, "suffix": ".sha256" }
     ]
   },
   {
     "code": 3,
-    "type": "diffie-hellman",
+    "type": "key",
     "formats": [
-      { "code": 0, "format": "curve25519", "data_length": 32, "key_length": 32 }
+      { "code": 0, "format": "envleope-dh", "data_length": 32, "key_length": 32 }
     ]
   },
   {
     "code": 4,
     "type": "signature",
     "formats": [
-      { "code": 0, "format": "ed25519", "data_length": 64, "signature_length": 64, "suffix": ".sig.ed25519" }
+      { "code": 0, "format": "content-ed25519", "data_length": 64, "signature_length": 64, "suffix": ".sig.ed25519" }
     ]
   },
   {
@@ -57,10 +57,10 @@
     "code": 6,
     "type": "generic",
     "formats": [
-      { "code": 0, "format": "UTF8 string" },
+      { "code": 0, "format": "string-UTF8" },
       { "code": 1, "format": "boolean" },
       { "code": 2, "format": "nil" },
-      { "code": 3, "format": "arbitrary bytes" }
+      { "code": 3, "format": "any-bytes" }
     ]
   }
 ]

--- a/bfe.json
+++ b/bfe.json
@@ -32,7 +32,7 @@
   },
   {
     "code": 3,
-    "type": "key",
+    "type": "encryption-key",
     "formats": [
       { "code": 0, "format": "box2-dm-dh", "data_length": 32, "key_length": 32 },
       { "code": 0, "format": "box2-pobox-dh", "data_length": 32, "key_length": 32 }


### PR DESCRIPTION
:warning: assumes https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec/pull/11 is merged

## context

on an @arj03 @mixmix @keks  call discussing proposed changes with POBox, we got stuck into asking "what is a type, what is a format".
I think we arrived at an idea like:
- a "type" is like a domain, a grouping based on similar functions that you would want to perform
- a "format" is a associated with a specific "recipe" in that type/domain
    - this recipe includes algorithm AND context (e.g. this is a signature of a bendy but content field)
    - it's not useful / safe enough to just say "ed25519"

we also realised that some type/formats are locked in by use, but the naming of it is still flexible. This means that e.g. type 3, format 0, which was "diffie-hellman, ed25519" is being proposed to rename to "key, box2-dh".
This reflects the realisation that "diffie-hellman" is waaaay too vague and what we actually want to be able to talk about are encryption keys, and which exact recipes (format) they were used in

### naming of fields

so naming is going to change some because we've realised some of the types/ formats were not tight enough.

I am also interested in changing names so that we can easily use names programatically when importing `bfe.json`.

Use cases:
- we're using `bfe.json` in `ssb-bfe` and we have functions which depend on the type/format string names
- I want to write functions which use this `bfe.json` definition to generate SSB-URIs for some types.

**proposals**
1. we use the same name in `README.md` as in `bfe.json`
    - e.g. if type 0 = `msg` we use `msg` in the docs
2. we don't use names with `/` or `\s` in them
    - this makes creating and parsing a URI harder
3. we choose relatively short names
    - prettier, shorter URIs
    - if this is a challenge we could split out e.g. `type.type` into  `type.textHandle" and "type.description"
        - if we do this, we could relax (1)

This PR executes these proposals to show more explicitly what I mean