### PR TITLE
correct dh key type-format

### DIFF
--- a/bfe.json
+++ b/bfe.json
@@ -35,7 +35,7 @@
     "code": 3,
     "type": "diffie-hellman",
     "formats": [
-      { "code": 0, "format": "curve25519", "data_length": 32, "key_length": 32 }
+      { "code": 0, "format": "curve25519" }
     ]
   },
   {


### PR DESCRIPTION
:warning: assume https://github.com/ssb-ngi-pointer/ssb-binary-field-encodings-spec/pull/11 merged

## context

type 3, format 0 is currently used in `ssb-tribes` to encode diffie-hellman keys when direct messaging. Notably this type/format is used for both public and secret dh keys, therefore the length is not === 32 (that's only the pk)