### PR TITLE
more tests

### DIFF
--- a/bfe.test.js
+++ b/bfe.test.js
@@ -2,6 +2,15 @@ const tape = require('tape')
 const bfeTypes = require('./bfe.json')
 
 tape('bfe', function (t) {
+  t.true(
+    bfeTypes.every((type, i) => {
+      return (type.code === i) && type.formats.every((format, j) => {
+        return format.code === j
+      })
+    }),
+    'type and format codes are reflected by bfe.json structure'
+  )
+
   const sigiledTypes = bfeTypes.reduce((acc, type) => {
     if (type.sigil) return [...acc, type]
     return acc

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   },
   "main": "bfe.json",
   "scripts": {
-    "test": "tape *.test.js | tap-spec"
-  },
+    "test": "tape *.test.js | tap-spec",
+    "prepublishOnly": "npm run test"
+  }, 
   "author": "public-domain",
   "contributors": [
     "Anders Rune Jensen <arj03@protonmail.ch>",


### PR DESCRIPTION
context:
- we programatically assume that the arrays entries in bfe.json are the same as the codes in those arrays.
- we don't run tests before publish

this PR addresses these two things. Note prepublish and prepublishOnly is recommended. opted not to install husky to reduce deps in this module