### PR TITLE
adjust bfe.json so that only classic has sigils

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ as **T-F-D**:
  | Type code   | Referencing        | In `bfe.json`    |
  |:-----------:| ------------------ | ---------------- |
  | 0           | Feed ID            | `feed`           |
- | 1           | Message ID         | `msg`            |
+ | 1           | Message ID         | `message`        |
  | 2           | Blob ID            | `blob`           |
  | 3           | Encryption key     | `encryption-key` |
  | 4           | Signature          | `signature`      |
@@ -30,12 +30,12 @@ as **T-F-D**:
 A feed ID TFD represents the public portion of a cryptographic keypair used to
 identify a feed, and verify message signatures.
 
-| Type code | Format code | Data length | Specification      | In `bfe.json` |
-|:---------:|:-----------:|-------------|--------------------|---------------|
-| 0         | 0           | 32 bytes    | [Classic SSB Feed] | `classic`     |
-| 0         | 1           | 32 bytes    | [Gabby Grove]      | `gabby-grove` |
-| 0         | 2           | 32 bytes    | [Bamboo]           | `bamboo`      |
-| 0         | 3           | 32 bytes    | [Bendy Butt]       | `bendy-butt`  |
+| Type code | Format code | Data length | Specification      | In `bfe.json`  |
+|:---------:|:-----------:|-------------|--------------------|----------------|
+| 0         | 0           | 32 bytes    | [Classic SSB Feed] | `classic`      |
+| 0         | 1           | 32 bytes    | [Gabby Grove]      | `gabby-grove`  |
+| 0         | 2           | 32 bytes    | [Bamboo]           | `bamboo`       |
+| 0         | 3           | 32 bytes    | [Bendy Butt]       | `bendybutt-v1` |
 
 #### Example
 
@@ -62,13 +62,13 @@ A message ID TFD represents the hash that uniquely identifies a message
 published on a feed. Some message ID formats directly reference the hash
 algorithm utilized, while others leave it implicit in the specification.
 
-| Type code | Format code | Data length | Specification     | In `bfe.json` |
-|:---------:|:-----------:|-------------|-------------------|---------------|
-| 1         | 0           | 32 bytes    | [Classic SSB Msg] | `classic`     |
-| 1         | 1           | 32 bytes    | [Gabby Grove]     | `gabby-grove` |
-| 1         | 2           | 32 bytes    | [Private Group]   | `cloaked`     |
-| 1         | 3           | 64 bytes    | [Bamboo]          | `bamboo`      |
-| 1         | 4           | 32 bytes    | [Bendy Butt]      | `bendy-butt`  |
+| Type code | Format code | Data length | Specification     | In `bfe.json`  |
+|:---------:|:-----------:|-------------|-------------------|----------------|
+| 1         | 0           | 32 bytes    | [Classic SSB Msg] | `classic`      |
+| 1         | 1           | 32 bytes    | [Gabby Grove]     | `gabby-grove`  |
+| 1         | 2           | 32 bytes    | [Private Group]   | `cloaked`      |
+| 1         | 3           | 64 bytes    | [Bamboo]          | `bamboo`       |
+| 1         | 4           | 32 bytes    | [Bendy Butt]      | `bendybutt-v1` |
 
 #### Example
 

--- a/bfe.json
+++ b/bfe.json
@@ -2,32 +2,29 @@
   {
     "code": 0,
     "type": "feed",
-    "sigil": "@",
     "formats": [
-      { "code": 0, "format": "classic",     "data_length": 32, "suffix": ".ed25519"   },
-      { "code": 1, "format": "gabby-grove", "data_length": 32, "suffix": ".ggfeed-v1" },
-      { "code": 2, "format": "bamboo",      "data_length": 32, "suffix": ".bamboo" },
-      { "code": 3, "format": "bendy-butt",  "data_length": 32, "suffix": ".bbfeed-v1" }
+      { "code": 0, "format": "classic",      "data_length": 32, "sigil": "@", "suffix": ".ed25519" },
+      { "code": 1, "format": "gabby-grove",  "data_length": 32 },
+      { "code": 2, "format": "bamboo",       "data_length": 32 },
+      { "code": 3, "format": "bendybutt-v1", "data_length": 32 }
     ]
   },
   {
     "code": 1,
-    "type": "msg",
-    "sigil": "%",
+    "type": "message",
     "formats": [
-      { "code": 0, "format": "classic",     "data_length": 32, "suffix": ".sha256"   },
-      { "code": 1, "format": "gabby-grove", "data_length": 32, "suffix": ".ggmsg-v1" },
-      { "code": 2, "format": "cloaked",     "data_length": 32, "suffix": ".cloaked" },
-      { "code": 3, "format": "bamboo",      "data_length": 64, "suffix": ".bamboo" },
-      { "code": 4, "format": "bendy-butt",  "data_length": 32, "suffix": ".bbmsg-v1" }
+      { "code": 0, "format": "classic",      "data_length": 32, "sigil": "%", "suffix": ".sha256" },
+      { "code": 1, "format": "gabby-grove",  "data_length": 32 },
+      { "code": 2, "format": "cloaked",      "data_length": 32, "sigil": "%", "suffix": ".cloaked" },
+      { "code": 3, "format": "bamboo",       "data_length": 64 },
+      { "code": 4, "format": "bendybutt-v1", "data_length": 32 }
     ]
   },
   {
     "code": 2,
     "type": "blob",
-    "sigil": "&",
     "formats": [
-      { "code": 0, "format": "classic", "data_length": 32, "suffix": ".sha256" }
+      { "code": 0, "format": "classic", "data_length": 32, "sigil": "&", "suffix": ".sha256" }
     ]
   },
   {


### PR DESCRIPTION
- [x] Pending on https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec/pull/25 merged first

Context: See https://github.com/ssb-ngi-pointer/ssb-meta-feed-spec/issues/19, only classic SSB refs would have sigils, so I started working on updating `ssb-bfe` (JS) to use SSB URIs for all non-classic type/formats and it required updating `ssb-bfe-spec`.

The main change is in `bfe.json`, there is now `format.sigil` alongside `format.suffix`, whereas before it was `type.sigil` (making an assumption that the sigil applies universally for that type). I also renamed `msg` to `message` because if we are to use `bfe.json` programatically, we have to build the URI from it, and `ssb:msg/ed25519/` is not an official SSB URI, it's `ssb:message/ed25199/`.