### PR TITLE
Introduce canonical Gabby Grove format naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ as **T-F-D**:
 A feed ID TFD represents the public portion of a cryptographic keypair used to
 identify a feed, and verify message signatures.
 
-| Type code | Format code | Data length | Specification      | In `bfe.json`  |
-|:---------:|:-----------:|-------------|--------------------|----------------|
-| 0         | 0           | 32 bytes    | [Classic SSB Feed] | `classic`      |
-| 0         | 1           | 32 bytes    | [Gabby Grove]      | `gabby-grove`  |
-| 0         | 2           | 32 bytes    | [Bamboo]           | `bamboo`       |
-| 0         | 3           | 32 bytes    | [Bendy Butt]       | `bendybutt-v1` |
+| Type code | Format code | Data length | Specification      | In `bfe.json`   |
+|:---------:|:-----------:|-------------|--------------------|-----------------|
+| 0         | 0           | 32 bytes    | [Classic SSB Feed] | `classic`       |
+| 0         | 1           | 32 bytes    | [Gabby Grove]      | `gabbygrove-v1` |
+| 0         | 2           | 32 bytes    | [Bamboo]           | `bamboo`        |
+| 0         | 3           | 32 bytes    | [Bendy Butt]       | `bendybutt-v1`  |
 
 #### Example
 
@@ -62,13 +62,13 @@ A message ID TFD represents the hash that uniquely identifies a message
 published on a feed. Some message ID formats directly reference the hash
 algorithm utilized, while others leave it implicit in the specification.
 
-| Type code | Format code | Data length | Specification     | In `bfe.json`  |
-|:---------:|:-----------:|-------------|-------------------|----------------|
-| 1         | 0           | 32 bytes    | [Classic SSB Msg] | `classic`      |
-| 1         | 1           | 32 bytes    | [Gabby Grove]     | `gabby-grove`  |
-| 1         | 2           | 32 bytes    | [Private Group]   | `cloaked`      |
-| 1         | 3           | 64 bytes    | [Bamboo]          | `bamboo`       |
-| 1         | 4           | 32 bytes    | [Bendy Butt]      | `bendybutt-v1` |
+| Type code | Format code | Data length | Specification     | In `bfe.json`   |
+|:---------:|:-----------:|-------------|-------------------|-----------------|
+| 1         | 0           | 32 bytes    | [Classic SSB Msg] | `classic`       |
+| 1         | 1           | 32 bytes    | [Gabby Grove]     | `gabbygrove-v1` |
+| 1         | 2           | 32 bytes    | [Private Group]   | `cloaked`       |
+| 1         | 3           | 64 bytes    | [Bamboo]          | `bamboo`        |
+| 1         | 4           | 32 bytes    | [Bendy Butt]      | `bendybutt-v1`  |
 
 #### Example
 

--- a/bfe.json
+++ b/bfe.json
@@ -4,7 +4,7 @@
     "type": "feed",
     "formats": [
       { "code": 0, "format": "classic",      "data_length": 32, "sigil": "@", "suffix": ".ed25519" },
-      { "code": 1, "format": "gabby-grove",  "data_length": 32 },
+      { "code": 1, "format": "gabbygrove-v1",  "data_length": 32 },
       { "code": 2, "format": "bamboo",       "data_length": 32 },
       { "code": 3, "format": "bendybutt-v1", "data_length": 32 }
     ]
@@ -14,7 +14,7 @@
     "type": "message",
     "formats": [
       { "code": 0, "format": "classic",      "data_length": 32, "sigil": "%", "suffix": ".sha256" },
-      { "code": 1, "format": "gabby-grove",  "data_length": 32 },
+      { "code": 1, "format": "gabbygrove-v1",  "data_length": 32 },
       { "code": 2, "format": "cloaked",      "data_length": 32, "sigil": "%", "suffix": ".cloaked" },
       { "code": 3, "format": "bamboo",       "data_length": 64 },
       { "code": 4, "format": "bendybutt-v1", "data_length": 32 }


### PR DESCRIPTION
`gabby-grove` -> `gabbygrove-v1`

Related to https://github.com/ssb-ngi-pointer/ssb-uri-spec/pull/9 and https://github.com/staltz/ssb-uri2/pull/3