### PR TITLE
Remove key_length from spec data

### DIFF
--- a/bfe.json
+++ b/bfe.json
@@ -31,8 +31,8 @@
     "code": 3,
     "type": "encryption-key",
     "formats": [
-      { "code": 0, "format": "box2-dm-dh", "data_length": 32, "key_length": 32 },
-      { "code": 1, "format": "box2-pobox-dh", "data_length": 32, "key_length": 32 }
+      { "code": 0, "format": "box2-dm-dh", "data_length": 32 },
+      { "code": 1, "format": "box2-pobox-dh", "data_length": 32 }
     ]
   },
   {


### PR DESCRIPTION
While reviewing one of my PR's for `ssb-bfe-rs`, @staltz noticed that we have redundant data in `bfe.json` (https://github.com/ssb-ngi-pointer/ssb-bfe-rs/pull/9#discussion_r720269293).

The `encryption-key` type has both a `data_length` and a `key_length`. This PR simply removes the redundant data.

I believe the next step will be to update `ssb-bfe` to use `format.data_length` in place of `format.key_length` in this single location: https://github.com/ssb-ngi-pointer/ssb-bfe/blob/7ea8dfe38749d496d528ec0eac30e6e670e133fb/util.js#L17